### PR TITLE
Batch signing

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -72,7 +72,7 @@ where
     }
 
     /// Save data to be signed later
-    pub fn add_to_pending_sign(&mut self, message: &[u8]) -> Result<()> {
+    pub fn add_to_pending(&mut self, message: &[u8]) -> Result<()> {
         match self {
             Self::Root { pending_sign, .. } | Self::Sub { pending_sign, .. } => 
                 pending_sign.push(message.into()),
@@ -82,7 +82,7 @@ where
 
     /// Try to sign messages from the queue
     /// Return signed messages
-    pub fn sign_all_pending(&mut self) -> Vec<(Vec<u8>, P::Signature)> {
+    pub fn sign_pending(&mut self) -> Vec<(Vec<u8>, P::Signature)> {
         let mut signed = Vec::new();
         let mut pending = match self {
             Self::Root { pending_sign, .. } | Self::Sub { pending_sign, .. } => pending_sign.clone()
@@ -95,7 +95,7 @@ where
         signed
     }
     
-    pub fn get_pending_sign(&self) -> Vec<Vec<u8>> {
+    pub fn get_pending(&self) -> Vec<Vec<u8>> {
         let pending = self.pending_sign();
         pending.iter().map(|i| i.clone()).collect()
     }

--- a/src/account.rs
+++ b/src/account.rs
@@ -83,16 +83,15 @@ where
     /// Try to sign messages from the queue
     /// Return signed messages
     pub fn sign_pending(&mut self) -> Vec<(Vec<u8>, P::Signature)> {
-        let mut signed = Vec::new();
         let mut pending = match self {
-            Self::Root { pending_sign, .. } | Self::Sub { pending_sign, .. } => pending_sign.clone()
+            Self::Root { pending_sign, .. } | Self::Sub { pending_sign, .. } => {
+                let pending = pending_sign.clone();
+                pending_sign.clear();
+                pending
+            }
         };
-        while !pending.is_empty() {
-            let msg = pending.pop().unwrap();
-            let signature = self.sign(&msg);
-            signed.push((msg, signature));
-        }
-        signed
+
+        pending.drain(..).map(|msg| (msg.clone(), self.sign(&msg))).collect()
     }
     
     pub fn get_pending(&self) -> Vec<Vec<u8>> {

--- a/src/account.rs
+++ b/src/account.rs
@@ -96,7 +96,17 @@ where
         }
         signed
     }
-
+    
+    pub fn get_pending_sign(&self) -> Vec<Vec<u8>> {
+        let pending = self.pending_sign();
+        pending.borrow().iter().map(|i| i.clone()).collect()
+    }
+    
+    fn pending_sign(&self) -> &RefCell<VecDeque<Vec<u8>>> {
+        match self {
+            Self::Root { pending_sign, .. } | Self::Sub { pending_sign, .. } => pending_sign
+        }
+    }
 }
 
 impl<P: Pair> CryptoType for Account<'_, P> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ where
     V: Vault<C>,
 {
     fn from(vault: V) -> Self {
-        Wallet { vault, root: None }
+        Wallet { vault, root: None, }
     }
 }
 
@@ -106,6 +106,17 @@ where
     pub fn sign(&self, message: &[u8]) -> Result<SignatureOf<V, C>> {
         Ok(self.root_account()?.sign(message))
     }
+
+    /// Try to sign all messages in the queue of an account
+    /// Returns signed transactions 
+    pub fn sign_pending(self, name: &str) -> Vec<SignatureOf<V, C>> {
+        match name {
+            "ROOT" => 
+                self.root.map(|mut a| a.sign_all_pending()).unwrap_or(Vec::new()),
+            _ => todo!(),
+        }
+    }
+    
 
     /// Switch the network used by the root account which is used by
     /// default when deriving new sub-accounts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,18 @@ where
 
     /// Try to sign all messages in the queue of an account
     /// Returns signed transactions 
+    /// ```
+    /// # use libwallet::{Wallet, SimpleVault, sr25519, Result};
+    /// # #[async_std::main] async fn main() -> Result<()> {
+    ///
+    /// let mut wallet = Wallet::new(SimpleVault::<sr25519::Pair>::new()).unlock(()).await?;
+    /// wallet.sign_later(&[0x01, 0x02, 0x03]);
+    /// wallet.sign_later(&[0x01, 0x02]);
+    /// wallet.sign_pending("ROOT");
+    /// let res = wallet.get_pending("ROOT");
+    /// assert!(res.is_empty());
+    /// # Ok(()) }
+    /// ```
     pub fn sign_pending(&mut self, name: &str) -> Vec<(Vec<u8>, SignatureOf<V, C>)> {
         match name {
             "ROOT" => 
@@ -137,9 +149,10 @@ where
     /// # #[async_std::main] async fn main() -> Result<()> {
     ///
     /// let mut wallet = Wallet::new(SimpleVault::<sr25519::Pair>::new()).unlock(()).await?;
-    /// wallet.save_to_sign_later(&[0x01, 0x02, 0x03]);
+    /// wallet.sign_later(&[0x01, 0x02, 0x03]);
+    /// wallet.sign_later(&[0x01, 0x02]);
     /// let res = wallet.get_pending("ROOT");
-    /// assert_eq!(vec![vec![0x01, 0x02, 0x03]], res);
+    /// assert_eq!(vec![vec![0x01, 0x02, 0x03], vec![0x01, 0x02]], res);
     /// # Ok(()) }
     /// ```
     pub fn get_pending(&self, name: &str) -> Vec<Vec<u8>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,12 +113,12 @@ where
     /// # #[async_std::main] async fn main() -> Result<()> {
     ///
     /// let mut wallet = Wallet::new(SimpleVault::<sr25519::Pair>::new()).unlock(()).await?;
-    /// let res = wallet.save_to_sign_later(&[0x01, 0x02, 0x03]);
+    /// let res = wallet.sign_later(&[0x01, 0x02, 0x03]);
     /// assert!(res.is_ok());
     /// # Ok(()) }
     /// ```
-    pub fn save_to_sign_later(&mut self, message: &[u8]) -> Result<()> {
-        self.root.as_mut().map(|a| a.add_to_pending_sign(message)).unwrap_or(Err(Error::Locked))
+    pub fn sign_later(&mut self, message: &[u8]) -> Result<()> {
+        self.root.as_mut().map(|a| a.add_to_pending(message)).unwrap_or(Err(Error::Locked))
     }
 
     /// Try to sign all messages in the queue of an account
@@ -126,7 +126,7 @@ where
     pub fn sign_pending(&mut self, name: &str) -> Vec<(Vec<u8>, SignatureOf<V, C>)> {
         match name {
             "ROOT" => 
-                self.root.as_mut().map(|a| a.sign_all_pending()).unwrap_or(Vec::new()),
+                self.root.as_mut().map(|a| a.sign_pending()).unwrap_or(Vec::new()),
             _ => todo!(), //search sub-accounts
         }
     }
@@ -138,13 +138,13 @@ where
     ///
     /// let mut wallet = Wallet::new(SimpleVault::<sr25519::Pair>::new()).unlock(()).await?;
     /// wallet.save_to_sign_later(&[0x01, 0x02, 0x03]);
-    /// let res = wallet.check_data_pending_sign("ROOT");
+    /// let res = wallet.get_pending("ROOT");
     /// assert_eq!(vec![vec![0x01, 0x02, 0x03]], res);
     /// # Ok(()) }
     /// ```
-    pub fn check_data_pending_sign(&self, name: &str) -> Vec<Vec<u8>> {
+    pub fn get_pending(&self, name: &str) -> Vec<Vec<u8>> {
         match name {
-            "ROOT" => self.root_account().unwrap().get_pending_sign(),
+            "ROOT" => self.root_account().unwrap().get_pending(),
             _ => todo!(), //get sub-accounts
         }
     }

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -11,7 +11,7 @@ impl<P: Pair> SimpleVault<P> {
     /// # use libwallet::{SimpleVault, Vault, Result, sr25519};
     /// # #[async_std::main] async fn main() -> Result<()> {
     /// let vault = SimpleVault::<sr25519::Pair>::new();
-    /// assert!(vault.unlock("").await.is_ok());
+    /// assert!(vault.unlock(()).await.is_ok());
     /// # Ok(()) }
     /// ```
     #[cfg(feature = "std")]


### PR DESCRIPTION
Add queue to account so it can save transactions to be sign later. New functionality in wallet to get de queue of transactions pending to sign, add a new transaction to the queue, and sign all pending transactions.